### PR TITLE
Fix boost installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,10 @@ with open(path.join(here, 'pypi_description'), encoding='utf-8') as f:
 # setup C++ extension
 # make sure libraries exist if C++ extension is to be compiled
 dylibsOnPath = all([path.exists('lib%s.%s'%(f,dynlibSuffix)) for f in dylibNames])
-dylibsInSearchDrs = all([path.exists('%s/lib%s.%s'%(dr,f,dynlibSuffix))
-                         for f in dylibNames
-                         for dr in DEFAULT_LIBRARY_DR])
+dylibsInSearchDrs = any([
+                        all([ path.exists('%s/lib%s.%s'%(dr,f,dynlibSuffix))
+                              for f in dylibNames ])
+                        for dr in DEFAULT_LIBRARY_DR ])
 if not NO_BOOST and (dylibsOnPath or dylibsInSearchDrs):
     samplersModule = Extension('coniii.samplers_ext',
                                include_dirs = ['./cpp'],

--- a/setup.py
+++ b/setup.py
@@ -37,15 +37,15 @@ NO_BOOST = False
 
 # setup
 here = path.abspath(path.dirname(__file__))
-system = platform.system()
-if system=='Linux':
-    dynlibSuffix = 'so'
-    DEFAULT_LIBRARY_DR=['/usr/local/lib', '/usr/lib/x86_64-linux-gnu']  # default places to search for boost lib
-elif system=='Darwin':
-    dynlibSuffix = 'dylib'
-    DEFAULT_LIBRARY_DR=['/usr/local/lib']  # default places to search for boost lib
-else:
-    raise Exception("System unrecognized.")
+#system = platform.system()
+#if system=='Linux':
+#    dynlibSuffix = 'so'
+#    DEFAULT_LIBRARY_DR=['/usr/local/lib', '/usr/lib/x86_64-linux-gnu']  # default places to search for boost lib
+#elif system=='Darwin':
+#    dynlibSuffix = 'dylib'
+#    DEFAULT_LIBRARY_DR = ['/usr/local/lib']  # default places to search for boost lib
+#else:
+#    raise Exception("System unrecognized.")
 dylibNames = ['boost_python37', 'boost_numpy37']
 
 # copy license into package
@@ -57,28 +57,28 @@ with open(path.join(here, 'pypi_description'), encoding='utf-8') as f:
 
 # setup C++ extension
 # make sure libraries exist if C++ extension is to be compiled
-dylibsOnPath = all([path.exists('lib%s.%s'%(f,dynlibSuffix)) for f in dylibNames])
-dylibsInSearchDrs = any([
-                        all([ path.exists('%s/lib%s.%s'%(dr,f,dynlibSuffix))
-                              for f in dylibNames ])
-                        for dr in DEFAULT_LIBRARY_DR ])
-if not NO_BOOST and (dylibsOnPath or dylibsInSearchDrs):
-    samplersModule = Extension('coniii.samplers_ext',
-                               include_dirs = ['./cpp'],
-                               library_dirs=DEFAULT_LIBRARY_DR,
-                               sources=['./cpp/samplers.cpp', './cpp/py.cpp'],
-                               extra_objects=['-l%s'%f for f in dylibNames],
-                               extra_compile_args=['-std=c++11'],
-                               language='c++')
-    ext_modules = [samplersModule]
-else:
-    ext_modules = []
-    print("--------------------------------------------------")
-    print("************ coniii setup.py WARNING *************")
-    print("Boost dynamic libraries could not be found.")
-    print("Boost will not be compiled.")
-    print("Please look for troubleshooting tips in README.md.")
-    print("--------------------------------------------------")
+#dylibsOnPath = all([path.exists('lib%s.%s'%(f,dynlibSuffix)) for f in dylibNames])
+#dylibsInSearchDrs = any([
+#                        all([ path.exists('%s/lib%s.%s'%(dr,f,dynlibSuffix))
+#                              for f in dylibNames ])
+#                        for dr in DEFAULT_LIBRARY_DR ])
+#if not NO_BOOST and (dylibsOnPath or dylibsInSearchDrs):
+samplersModule = Extension('coniii.samplers_ext',
+                           include_dirs = ['./cpp'],
+                           #library_dirs=DEFAULT_LIBRARY_DR,
+                           sources=['./cpp/samplers.cpp', './cpp/py.cpp'],
+                           extra_objects=['-l%s'%f for f in dylibNames],
+                           extra_compile_args=['-std=c++11'],
+                           language='c++')
+ext_modules = [samplersModule]
+#else:
+#    ext_modules = []
+#    print("--------------------------------------------------")
+#    print("************ coniii setup.py WARNING *************")
+#    print("Boost dynamic libraries could not be found.")
+#    print("Boost will not be compiled.")
+#    print("Please look for troubleshooting tips in README.md.")
+#    print("--------------------------------------------------")
 
 # compile
 setup(name='coniii',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,12 @@ if not NO_BOOST and (dylibsOnPath or dylibsInSearchDrs):
     ext_modules = [samplersModule]
 else:
     ext_modules = []
-    print("Dynamic libraries not on path. Boost not compiled.")
+    print("--------------------------------------------------")
+    print("************ coniii setup.py WARNING *************")
+    print("Boost dynamic libraries could not be found.")
+    print("Boost will not be compiled.")
+    print("Please look for troubleshooting tips in README.md.")
+    print("--------------------------------------------------")
 
 # compile
 setup(name='coniii',


### PR DESCRIPTION
This branch is not yet ready to be merged in, but serves as a place to work on this issue.

Currently it seems the best option for installing boost on Mac would be using anaconda (`conda install -c anaconda boost`), as this would mean we wouldn't require people to have homebrew or macports.

The compilation in `pypi_compile.sh` works for me (I get a compiled `samplers_ext...` file).  The code seems to find the boost library files without help, so I removed the stuff in `setup.py` setting `DEFAULT_LIBRARY_DIR` and looking for the files explicitly.

The issue now is that the compiled code won't import.  I get the following error
```
~/anaconda2/envs/python3/lib/python3.7/site-packages/coniii/samplers.py in <module>
     35 from warnings import warn
     36 try:
---> 37     from .samplers_ext import BoostIsing, BoostPotts3
     38     IMPORTED_SAMPLERS_EXT = True
     39 except ModuleNotFoundError:

ImportError: dlopen(/Users/bryandaniels/anaconda2/envs/python3/lib/python3.7/site-packages/coniii/samplers_ext.cpython-37m-darwin.so, 2): Symbol not found: __ZN5boost6python7objects15function_objectERKNS1_11py_functionERKSt4pairIPKNS0_6detail7keywordES9_E
  Referenced from: /Users/bryandaniels/anaconda2/envs/python3/lib/python3.7/site-packages/coniii/samplers_ext.cpython-37m-darwin.so
  Expected in: flat namespace
 in /Users/bryandaniels/anaconda2/envs/python3/lib/python3.7/site-packages/coniii/samplers_ext.cpython-37m-darwin.so
```

Finally: Instead of checking in `setup.py` that the library files are in some expected location, it seems maybe better to just try compiling and print out an error at the end if we don't end up with a `samplers_ext...` file.  It looks like the end of `pypi_compile.sh` is trying to do something like this, but really just checks whether there is a build folder at all?  This doesn't catch cases where the C code doesn't compile but the rest of `setup.py` works.